### PR TITLE
Add trusty as an OS option

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,17 +10,17 @@ class dhcp::params {
     /Debian|Ubuntu/: {
       $config_dir = $::lsbdistcodename? {
         /lenny|lucid/  => '/etc/dhcp3',
-        /squeeze|wheezy|precise/ => '/etc/dhcp',
+        /squeeze|wheezy|precise|trusty/ => '/etc/dhcp',
       }
 
       $srv_dhcpd = $::lsbdistcodename? {
         /lenny|lucid/            => 'dhcp3-server',
-        /squeeze|wheezy|precise/ => 'isc-dhcp-server',
+        /squeeze|wheezy|precise|trusty/ => 'isc-dhcp-server',
       }
 
       $service_pattern = $::lsbdistcodename? {
         /lenny|lucid/           => '/usr/sbin/dhcpd3',
-        /squeeze|wheezy|precise/ => '/usr/sbin/dhcpd',
+        /squeeze|wheezy|precise|trusty/ => '/usr/sbin/dhcpd',
       }
 
       $server_template = "${module_name}/dhcpd.conf.debian.erb"


### PR DESCRIPTION
Just expanded the expression to add trusty, nothing seems to have changed since precise.