### PR TITLE
Add RedHat/CentOS support

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,5 +1,5 @@
 --fail-on-warnings
 --relative
---no-80chars
+--no-140chars
 --no-documentation
 --no-class_inherits_from_params_class-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,6 @@ matrix:
     sudo: required
     dist: trusty
     services: docker
-    env: BEAKER_set="centos-5"
-    bundler_args:
-    script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
-  - rvm: default
-    sudo: required
-    dist: trusty
-    services: docker
     env: BEAKER_set="centos-6"
     bundler_args:
     script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
-  - rvm: 2.1.7
-    env: PUPPET_GEM_VERSION="~> 4.0"
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.5.0"
   - rvm: default
     sudo: required
     dist: trusty
@@ -61,4 +61,4 @@ deploy:
     # all_branches is required to use tags
     all_branches: true
     # Only publish if our main Ruby target builds
-    rvm: 2.1.7
+    rvm: 2.1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,27 @@ matrix:
     env: BEAKER_set="ubuntu-14.04"
     bundler_args:
     script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
+  - rvm: default
+    sudo: required
+    dist: trusty
+    services: docker
+    env: BEAKER_set="centos-5"
+    bundler_args:
+    script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
+  - rvm: default
+    sudo: required
+    dist: trusty
+    services: docker
+    env: BEAKER_set="centos-6"
+    bundler_args:
+    script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
+  - rvm: default
+    sudo: required
+    dist: trusty
+    services: docker
+    env: BEAKER_set="centos-7"
+    bundler_args:
+    script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
 notifications:
   email: false
 deploy:

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :development, :unit_tests do
   gem 'puppet-lint-unquoted_string-check',                 :require => false
   gem 'puppet-lint-empty_string-check',                    :require => false
   gem 'puppet-lint-spaceship_operator_without_tag-check',  :require => false
-  gem 'puppet-lint-variable_contains_upcase',              :require => false
   gem 'puppet-lint-absolute_classname-check',              :require => false
   gem 'puppet-lint-undef_in_function-check',               :require => false
   gem 'puppet-lint-leading_zero-check',                    :require => false
@@ -22,6 +21,7 @@ group :development, :unit_tests do
   gem 'rspec-puppet-facts',                                :require => false
   gem 'ruby-augeas',                                       :require => false
   gem 'puppet-blacksmith',                                 :require => false if RUBY_VERSION !~ /^1\./
+  gem 'json_pure', '< 2.0.2',                              :require => false
 end
 
 group :system_tests do

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'puppet-lint/tasks/puppet-lint'
 Rake::Task[:lint].clear
 PuppetLint::RakeTask.new :lint do |config|
   config.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vendor/**/*.pp"]
-  config.disable_checks = ['80chars']
+  config.disable_checks = ['140chars']
   config.fail_on_warnings = true
 end
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,9 +9,12 @@ class dhcp::params {
       $package_dhcpd = 'dhcp'
       $srv_dhcpd = 'dhcpd'
     }
-    default: {
+    'Debian': {
       $package_dhcpd = 'isc-dhcp-server'
       $srv_dhcpd = 'isc-dhcp-server'
+    }
+    default: {
+      fail('::dhcp not supported on this OS')
     }
   }
   $config_dir = '/etc/dhcp'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@
 #
 class dhcp::params {
   case $::osfamily {
-    /RedHat/: {
+    'RedHat': {
       $package_dhcpd = 'dhcp'
       $srv_dhcpd = 'dhcpd'
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,8 +4,17 @@
 # Set variables for names and paths
 #
 class dhcp::params {
+  case $::osfamily {
+    /RedHat/: {
+      $package_dhcpd = 'dhcp'
+      $srv_dhcpd = 'dhcpd'
+    }
+    default: {
+      $package_dhcpd = 'isc-dhcp-server'
+      $srv_dhcpd = 'isc-dhcp-server'
+    }
+  }
   $config_dir = '/etc/dhcp'
-  $srv_dhcpd = 'isc-dhcp-server'
   $service_pattern = '/usr/sbin/dhcpd'
   $server_template = "${module_name}/dhcpd.conf.debian.erb"
 }

--- a/manifests/server/packages.pp
+++ b/manifests/server/packages.pp
@@ -5,11 +5,11 @@
 class dhcp::server::packages {
   include ::dhcp::params
 
-  validate_string($dhcp::params::srv_dhcpd)
-  validate_re($dhcp::params::srv_dhcpd, '^\S+$')
+  validate_string($dhcp::params::package_dhcpd)
+  validate_re($dhcp::params::package_dhcpd, '^\S+$')
 
   package {'dhcp-server':
     ensure => present,
-    name   => $dhcp::params::srv_dhcpd,
+    name   => $dhcp::params::package_dhcpd,
   }
 }

--- a/manifests/subnet.pp
+++ b/manifests/subnet.pp
@@ -26,7 +26,7 @@
 define dhcp::subnet(
   $broadcast,
   $ensure = present,
-  $netmask = undef,
+  $netmask = $::netmask,
   $routers = [],
   $subnet_mask = undef,
   $domain_name = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-	"5",
 	"6",
         "7"
       ]
@@ -44,7 +43,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-	"5",
 	"6",
         "7"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -36,12 +36,16 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
+	"5",
+	"6",
         "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
+	"5",
+	"6",
         "7"
       ]
     }

--- a/metadata.json
+++ b/metadata.json
@@ -32,6 +32,18 @@
       "operatingsystemrelease": [
         "14.04"
       ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7"
+      ]
     }
   ]
 }

--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -24,6 +24,11 @@ describe 'dhcp' do
           let(:srv_name) { 'isc-dhcp-server' }
           let(:srv_pattern) { '/usr/sbin/dhcpd' }
         end
+      when 'RedHat'
+        let(:pkg_name) { 'dhcp' }
+        let(:confdir) { '/etc/dhcp' }
+        let(:srv_name) { 'dhcpd' }
+        let(:srv_pattern) { '/usr/sbin/dhcpd' }
       end
 
       # Package

--- a/templates/subnet.conf.erb
+++ b/templates/subnet.conf.erb
@@ -6,7 +6,7 @@
 subnet <%= @name %> netmask <%= _netmask %> {
 <%-
   _routers = @routers unless @routers.empty?
-  _routers ||= [scope.lookupvar('::netmask_eth0')]
+  _routers ||= [scope.lookupvar('::netmask')]
   scope.function_validate_array([_routers]) -%>
   option routers <%= _routers.collect! {|i| "#{i}" }.join(',') %>;
 <%-


### PR DESCRIPTION
I've made some small changes needed for supporting RedHat family systems. The changes needed were very minor, mostly dealing with the fact that the package and service name don't match.

Only CentOS/RHEL 7 have been tested as that's my target, I'll check support on CentOS 6 as soon as I can.

Add case for osfamily to select package and service names.
Separate the package and service names
Add RedHat and CentOS support to the metadata