### PR TITLE
concat ensure is deprecated and should not be used

### DIFF
--- a/spec/defines/dhcp_subnet_spec.rb
+++ b/spec/defines/dhcp_subnet_spec.rb
@@ -192,9 +192,8 @@ describe 'dhcp::subnet' do
           :is_shared => true,
         } }
 
-        it { should contain_concat__fragment('dhcp.subnet.1.2.3.4').with(
-          :ensure  => 'absent'
-        ) }
+        it { should_not contain_concat__fragment('dhcp.subnet.1.2.3.4')
+        }
       end
 
       context 'when passing other_opts as array' do


### PR DESCRIPTION
concat ensure is a deprecated parameter.
This commit breaks unit tests on purpose, next PR will fix them.