### PR TITLE
Fix/concat ensure

### DIFF
--- a/manifests/failover.pp
+++ b/manifests/failover.pp
@@ -18,13 +18,13 @@ define dhcp::failover(
 
   include ::dhcp::params
 
-  $_ensure = $ensure? {
+  $my_ensure = $ensure? {
     'present' => 'file',
     default   => $ensure,
   }
 
   file {"${dhcp::params::config_dir}/failover.d/${name}.conf":
-    ensure  => $_ensure,
+    ensure  => $my_ensure,
     content => template("${module_name}/failover.conf.erb"),
     group   => 'root',
     mode    => '0644',
@@ -32,10 +32,11 @@ define dhcp::failover(
     owner   => 'root',
   }
 
-  concat::fragment {"dhcp.failover.${name}":
-    ensure  => $ensure,
-    content => "include \"${dhcp::params::config_dir}/failover.d/${name}.conf\";\n",
-    target  => "${dhcp::params::config_dir}/dhcpd.conf",
+  if $ensure == 'present' {
+    concat::fragment {"dhcp.failover.${name}":
+      content => "include \"${dhcp::params::config_dir}/failover.d/${name}.conf\";\n",
+      target  => "${dhcp::params::config_dir}/dhcpd.conf",
+    }
   }
 
 }

--- a/manifests/hosts.pp
+++ b/manifests/hosts.pp
@@ -76,10 +76,11 @@ define dhcp::hosts (
   validate_array($global_options)
   validate_string($template)
 
-  concat::fragment {"dhcp.host.${name}":
-    ensure  => $ensure,
-    target  => "${dhcp::params::config_dir}/hosts.d/${subnet}.conf",
-    content => template($template),
-    notify  => Service['dhcpd'],
+  if $ensure == 'present' {
+    concat::fragment {"dhcp.host.${name}":
+      target  => "${dhcp::params::config_dir}/hosts.d/${subnet}.conf",
+      content => template($template),
+      notify  => Service['dhcpd'],
+    }
   }
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -26,7 +26,6 @@ class dhcp::server::config {
   }
 
   concat::fragment {'00.dhcp.server.base':
-    ensure  => present,
     target  => "${dhcp::params::config_dir}/dhcpd.conf",
     content => template($dhcp::params::server_template),
   }

--- a/manifests/shared_network.pp
+++ b/manifests/shared_network.pp
@@ -30,11 +30,12 @@ define dhcp::shared_network(
               "\$ensure must be either 'present' or 'absent', got '${ensure}'")
   validate_array($subnets)
 
-  concat::fragment {"dhcp-shared-${name}":
-    ensure  => $ensure,
-    target  => "${dhcp::params::config_dir}/dhcpd.conf",
-    content => template("${module_name}/shared-network.erb"),
-    require => Dhcp::Subnet[$subnets],
+  if $ensure == 'present' {
+    concat::fragment {"dhcp-shared-${name}":
+      target  => "${dhcp::params::config_dir}/dhcpd.conf",
+      content => template("${module_name}/shared-network.erb"),
+      require => Dhcp::Subnet[$subnets],
+    }
   }
 
 }

--- a/manifests/subnet.pp
+++ b/manifests/subnet.pp
@@ -65,26 +65,23 @@ define dhcp::subnet(
     notify  => Service['dhcpd'],
   }
 
-  $ensure_shared = $is_shared ? {
-    true  => 'absent',
-    false => $ensure,
-  }
-  concat::fragment {"dhcp.subnet.${name}":
-    ensure  => $ensure_shared,
-    target  => "${dhcp::params::config_dir}/dhcpd.conf",
-    content => "include \"${dhcp::params::config_dir}/subnets/${name}.conf\";\n",
+  unless $is_shared {
+    concat::fragment {"dhcp.subnet.${name}":
+      target  => "${dhcp::params::config_dir}/dhcpd.conf",
+      content => "include \"${dhcp::params::config_dir}/subnets/${name}.conf\";\n",
+    }
   }
 
-  concat::fragment {"dhcp.subnet.${name}.hosts":
-    ensure  => $ensure,
-    target  => "${dhcp::params::config_dir}/dhcpd.conf",
-    content => "include \"${dhcp::params::config_dir}/hosts.d/${name}.conf\";\n",
-  }
+  if $ensure == 'present' {
+    concat::fragment {"dhcp.subnet.${name}.hosts":
+      target  => "${dhcp::params::config_dir}/dhcpd.conf",
+      content => "include \"${dhcp::params::config_dir}/hosts.d/${name}.conf\";\n",
+    }
 
-  concat::fragment {"dhcp.subnet.${name}.base":
-    ensure  => $ensure,
-    target  => "${dhcp::params::config_dir}/hosts.d/${name}.conf",
-    content => "# File managed by puppet\n",
-    order   => '00',
+    concat::fragment {"dhcp.subnet.${name}.base":
+      target  => "${dhcp::params::config_dir}/hosts.d/${name}.conf",
+      content => "# File managed by puppet\n",
+      order   => '00',
+    }
   }
 }

--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -44,7 +44,6 @@ describe 'dhcp' do
       ) }
 
       it { should contain_concat__fragment('00.dhcp.server.base').with(
-        :ensure  => 'present',
         :target  => "#{confdir}/dhcpd.conf",
         :content => /log-facility/
       ).with_content(/ddns-update-style none;/).with_content(/#authoritative/)
@@ -77,7 +76,6 @@ describe 'dhcp' do
           } }
 
           it { should contain_concat__fragment('00.dhcp.server.base').with(
-            :ensure  => 'present',
             :target  => '/etc/dhcp/dhcpd.conf',
             :content => /log-facility/
           ).with_content(/ddns-update-style foo;/).with_content(/#authoritative/)
@@ -104,7 +102,6 @@ describe 'dhcp' do
           } }
 
           it { should contain_concat__fragment('00.dhcp.server.base').with(
-            :ensure  => 'present',
             :target  => '/etc/dhcp/dhcpd.conf',
             :content => /log-facility/
           ).with_content(/ddns-update-style none;/).with_content(/[^#]authoritative/)
@@ -131,7 +128,6 @@ describe 'dhcp' do
           } }
 
           it { should contain_concat__fragment('00.dhcp.server.base').with(
-            :ensure  => 'present',
             :target  => '/etc/dhcp/dhcpd.conf',
             :content => /log-facility/
           ).with_content(/ddns-update-style none;/).with_content(/#authoritative/).with_content(/foo;\nbar;\nbaz;\n/)

--- a/spec/defines/dhcp_shared_network_spec.rb
+++ b/spec/defines/dhcp_shared_network_spec.rb
@@ -37,7 +37,6 @@ describe 'dhcp::shared_network' do
 
       context 'when passing no parameters' do
         it { should contain_concat__fragment('dhcp-shared-My network').with(
-          :ensure  => 'present',
           :target  => '/etc/dhcp/dhcpd.conf'
         ).with_content(
           /shared-network My network \{\n\}/
@@ -75,7 +74,6 @@ describe 'dhcp::shared_network' do
         } }
 
         it { should contain_concat__fragment('dhcp-shared-My network').with(
-          :ensure => 'present',
           :target => '/etc/dhcp/dhcpd.conf'
         ).with_content(
           /shared-network My network \{\n  include "\/etc\/dhcp\/subnets\/1\.2\.3\.4\.conf";\n  include "\/etc\/dhcp\/subnets\/5\.6\.7\.8\.conf";\n\}/)

--- a/spec/defines/dhcp_subnet_spec.rb
+++ b/spec/defines/dhcp_subnet_spec.rb
@@ -192,9 +192,8 @@ describe 'dhcp::subnet' do
           :is_shared => true,
         } }
 
-        it { should contain_concat__fragment('dhcp.subnet.1.2.3.4').with(
-          :ensure  => 'absent'
-        ) }
+        it { should_not contain_concat__fragment('dhcp.subnet.1.2.3.4')
+        }
       end
 
       context 'when passing other_opts as array' do

--- a/spec/defines/dhcp_subnet_spec.rb
+++ b/spec/defines/dhcp_subnet_spec.rb
@@ -167,19 +167,16 @@ describe 'dhcp::subnet' do
         ) }
 
         it { should contain_concat__fragment('dhcp.subnet.1.2.3.4').with(
-          :ensure  => 'present',
           :target  => '/etc/dhcp/dhcpd.conf',
           :content => "include \"/etc/dhcp/subnets/1.2.3.4.conf\";\n"
         ) }
 
         it { should contain_concat__fragment('dhcp.subnet.1.2.3.4.hosts').with(
-          :ensure  => 'present',
           :target  => '/etc/dhcp/dhcpd.conf',
           :content => "include \"/etc/dhcp/hosts.d/1\.2\.3\.4\.conf\";\n"
         ) }
 
         it { should contain_concat__fragment('dhcp.subnet.1.2.3.4.base').with(
-          :ensure  => 'present',
           :target  => '/etc/dhcp/hosts.d/1.2.3.4.conf',
           :content => "# File managed by puppet\n",
           :order   => '00'


### PR DESCRIPTION
This removes the uses of concat ensure parameter in manifest and tests.
Fixes #21 